### PR TITLE
Add wrappers for define

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,7 +39,8 @@ env = Environment(CXXFLAGS="-std=c++11 " + FFLAGS + OPTFLAGS + WFLAGS)
 
 comm_env = env.Clone()
 comm_env.Replace(
-        CPPPATH = ['include', 'src'],
+        CPPPATH = ['include', 'src',
+                   os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include')],
         LIBS    = [],
         LIBPATH = []
              )
@@ -69,7 +70,8 @@ ulib = comm_env.SharedLibrary('lib/comm', comm_cc)
 
 client_env = comm_env.Clone()
 client_env.Replace(
-        CPPPATH = ['include', 'src'],
+        CPPPATH = ['include', 'src',
+                    os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include')],
         LIBS    = ['comm'],
         LIBPATH = ['lib/']
              )
@@ -89,11 +91,16 @@ ulib = client_env.SharedLibrary('lib/aperturedb-client', client_cc)
 CXXFLAGS = env['CXXFLAGS']
 
 # Comm Testing
-comm_test_env = Environment(CPPPATH  = ['include', 'src'],
-                            CXXFLAGS = CXXFLAGS,
-                            LIBS     = ['aperturedb-client', 'comm', 'pthread', 'gtest', 'glog'],
-                            LIBPATH  = ['lib/']
-                            )
+comm_test_env = Environment(
+        CPPPATH  = ['include', 'src',
+                    os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include')
+                   ],
+        CXXFLAGS = CXXFLAGS,
+        LIBS     = ['aperturedb-client', 'comm', 'pthread', 'gtest', 'glog'],
+        LIBPATH  = ['lib'],
+        RPATH    = ['../lib']
+        )
+
 
 comm_test_env.ParseConfig('pkg-config --cflags --libs protobuf')
 

--- a/include/comm/Macros.h
+++ b/include/comm/Macros.h
@@ -30,10 +30,14 @@
 
 #pragma once
 
+#ifndef MOVEABLE_BY_DEFAULT
 #define MOVEABLE_BY_DEFAULT(Type)       \
     Type(Type&&) = default;             \
     Type& operator=(Type&&) = default;
+#endif
 
+#ifndef NOT_COPYABLE
 #define NOT_COPYABLE(Type)                  \
     Type(const Type&) = delete;             \
     Type& operator=(const Type&) = delete;
+#endif


### PR DESCRIPTION
### Purpose
Add `#ifdef` wrapper for some `#define`s.

### Detail
The absense causes compilation issues of Athena in some setups: the macros in file `Macros.h` are included, unwrapped, via `aperturedb-cpp/include/...`, and also the very same macros are included via Athena's `Macros.h`.