### PR TITLE
Add wrapper for define

### DIFF
--- a/include/comm/Macros.h
+++ b/include/comm/Macros.h
@@ -30,10 +30,14 @@
 
 #pragma once
 
+#ifndef MOVEABLE_BY_DEFAULT
 #define MOVEABLE_BY_DEFAULT(Type)       \
     Type(Type&&) = default;             \
     Type& operator=(Type&&) = default;
+#endif
 
+#ifndef NOT_COPYABLE
 #define NOT_COPYABLE(Type)                  \
     Type(const Type&) = delete;             \
     Type& operator=(const Type&) = delete;
+#endif


### PR DESCRIPTION
### Purpose
Add a `#ifndef .. #endif` warpper for some `#define` to avoid compilation issues of Athena

### Detail
Projects `athena` and `aperturedb-cpp` have nearly-identical `Macros.h`. One of the files was "unwrapped" macros, which results in multiple definitions. This PR should resolve it.