### PR TITLE
fix metrics::TimedQueue

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -101,11 +101,21 @@ CXXFLAGS = env['CXXFLAGS']
 # Comm Testing
 comm_test_env = Environment(
         CPPPATH  = ['include', 'src',
-                    os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include')
+                    os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include'),
+                    os.getenv('PROMETHEUS_CPP_CORE_INCLUDE', default=''),
                    ],
         CXXFLAGS = CXXFLAGS,
-        LIBS     = ['aperturedb-client', 'comm', 'pthread', 'gtest', 'glog'],
-        LIBPATH  = ['lib'],
+        LIBS     = [
+                    'aperturedb-client',
+                    'comm',
+                    'pthread',
+                    'gtest',
+                    'glog',
+                    'prometheus-cpp-core',
+                   ],
+        LIBPATH  = ['lib',
+                    os.getenv('PROMETHEUS_CPP_LIB',  default=''),
+                   ],
         RPATH    = ['../lib']
         )
 
@@ -118,7 +128,8 @@ comm_test_source_files = [
                           'test/TCPConnectionTests.cc',
                           'test/TLSConnectionTests.cc',
                           'test/VDMSServer.cc',
-                          'test/VDMSServerTests.cc'
+                          'test/VDMSServerTests.cc',
+                          'test/TimedQueueTests.cc',
                          ]
 
 comm_test = comm_test_env.Program('test/comm_test', comm_test_source_files)

--- a/include/metrics/TimedQueue.h
+++ b/include/metrics/TimedQueue.h
@@ -23,7 +23,7 @@ class TimedQueue
 public:
     using value_type = T;
     using metric_type = METRIC_TYPE;
-    using timer_type = Timer<TIME_UNIT, metric_type>;
+    using timer_type = Timer<metric_type, TIME_UNIT>;
 private:
     std::list<std::pair<value_type, timer_type> > _queue;
     metric_type* _wait_timer;

--- a/test/TimedQueueTests.cc
+++ b/test/TimedQueueTests.cc
@@ -1,0 +1,89 @@
+/**
+ * @copyright Copyright (c) 2021 ApertureData Inc.
+ */
+
+#include <thread>
+
+#include "gtest/gtest.h"
+
+#include "metrics/TimedQueue.h"
+#include <prometheus/summary.h>
+
+using namespace prometheus;
+using namespace metrics;
+
+TEST(TimedQueueTest, Histogram)
+{
+    Histogram::BucketBoundaries buckets{0.01};
+    Histogram timer(buckets);
+    Counter pushes;
+    TimedQueue<int> queue(&timer, &pushes);
+    EXPECT_EQ(0.0, pushes.Value());
+
+    queue.push_back(1);
+    EXPECT_EQ(1.0, pushes.Value());
+    EXPECT_EQ(0, timer.Collect().histogram.sample_count);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    queue.push_back(2);
+    EXPECT_EQ(1, queue.release_front());
+    EXPECT_EQ(2, queue.release_front());
+
+    EXPECT_EQ(2.0, pushes.Value());
+    auto timer_val = timer.Collect();
+    EXPECT_EQ(2, timer_val.histogram.sample_count);
+
+    EXPECT_EQ(2, timer_val.histogram.bucket.size());
+    // total time spent in queue should exceed 10 ms
+    EXPECT_LT(0.01, timer_val.histogram.sample_sum);
+    // only one element should have spent less than 10 ms in the queue
+    EXPECT_EQ(1, timer_val.histogram.bucket[0].cumulative_count);
+}
+
+TEST(TimedQueueTest, Summary)
+{
+    Summary::Quantiles qtiles{};
+    Summary timer(qtiles);
+    Counter pushes;
+    TimedQueue<int, Summary> queue(&timer, &pushes);
+    EXPECT_EQ(0.0, pushes.Value());
+
+    queue.push_back(1);
+    queue.push_back(2);
+    EXPECT_EQ(2.0, pushes.Value());
+    EXPECT_EQ(0, timer.Collect().summary.sample_count);
+    EXPECT_EQ(1, queue.release_front());
+    EXPECT_EQ(2, queue.release_front());
+
+    EXPECT_EQ(2.0, pushes.Value());
+    auto timer_val = timer.Collect();
+    EXPECT_EQ(2, timer_val.summary.sample_count);
+}
+
+TEST(TimedQueueTest, Milliseconds)
+{
+    Histogram::BucketBoundaries buckets{10.0};
+    Histogram ms_timer(buckets);
+    Counter pushes;
+    TimedQueue<int, Histogram, std::chrono::milliseconds> queue(&ms_timer, &pushes);
+    EXPECT_EQ(0.0, pushes.Value());
+
+    queue.push_back(1);
+    EXPECT_EQ(1.0, pushes.Value());
+    EXPECT_EQ(0, ms_timer.Collect().histogram.sample_count);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    queue.push_back(2);
+    EXPECT_EQ(1, queue.release_front());
+    EXPECT_EQ(2, queue.release_front());
+
+    EXPECT_EQ(2.0, pushes.Value());
+    auto ms_timer_val = ms_timer.Collect();
+    EXPECT_EQ(2, ms_timer_val.histogram.sample_count);
+
+    EXPECT_EQ(2, ms_timer_val.histogram.bucket.size());
+    // total time spent in queue should exceed 10 ms
+    EXPECT_LT(10.0, ms_timer_val.histogram.sample_sum);
+    // only one element should have spent less than 10 ms in the queue
+    EXPECT_EQ(1, ms_timer_val.histogram.bucket[0].cumulative_count);
+}


### PR DESCRIPTION
This fixes a compilation failure introduced in #8 and adds tests.