### PR TITLE
Handle connection timeout

### DIFF
--- a/include/comm/Exception.h
+++ b/include/comm/Exception.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <string>
+#include <iostream>
 
 namespace comm {
 
@@ -65,6 +66,7 @@ namespace comm {
         // Additional information
         const std::string msg;
         const int errno_val;
+        const int ssl_err_code;
 
         // Where it was thrown
         const char * const file;   // Source file name
@@ -72,7 +74,7 @@ namespace comm {
 
         Exception(int exc, const char *exc_name, const char *f, int l)
             : num(exc), name(exc_name),
-              msg(), errno_val(0),
+              msg(), errno_val(0), ssl_err_code(0),
               file(f), line(l)
         {}
 
@@ -80,22 +82,34 @@ namespace comm {
                   const std::string &m,
                   const char *f, int l)
             : num(exc), name(exc_name),
-              msg(m), errno_val(0),
+              msg(m), errno_val(0), ssl_err_code(0),
+              file(f), line(l)
+        {}
+
+        Exception(int exc, const char *exc_name,
+                  int err, const char* m,
+                  int ssl_err,
+                  const char *f, int l)
+            : num(exc), name(exc_name),
+              msg(m), errno_val(err), ssl_err_code(ssl_err),
               file(f), line(l)
         {}
 
         Exception(int exc, const char *exc_name,
                   int err, const std::string &m,
+                  int ssl_err,
                   const char *f, int l)
             : num(exc), name(exc_name),
-              msg(m), errno_val(err),
+              msg(m), errno_val(err), ssl_err_code(ssl_err),
               file(f), line(l)
         {}
         Exception() = delete;
         Exception(const Exception&) = default;
         Exception& operator=(const Exception&) = delete;
+        friend std::ostream& operator<<(std::ostream&, const Exception&);
     };
 
+    std::ostream& operator<<(std::ostream&, const Exception&);
 };
 
 #define THROW_EXCEPTION(name, ...) \

--- a/src/comm/Connection.cc
+++ b/src/comm/Connection.cc
@@ -97,10 +97,10 @@ const std::basic_string<uint8_t>& Connection::recv_message()
     };
 
     size_t bytes_recv = recv_and_check(reinterpret_cast<uint8_t*>(&recv_message_size),
-                                       sizeof(uint32_t));
+                                       sizeof(recv_message_size));
 
     if (bytes_recv != sizeof(recv_message_size)) {
-        THROW_EXCEPTION(ReadFail);
+        THROW_EXCEPTION(ReadFail, "Short read msg header");
     }
 
     if (recv_message_size > _max_buffer_size) {
@@ -115,11 +115,11 @@ const std::basic_string<uint8_t>& Connection::recv_message()
     bytes_recv = recv_and_check(const_cast<uint8_t*>(_buffer_str.data()), recv_message_size);
 
     if (recv_message_size != bytes_recv) {
-        THROW_EXCEPTION(ReadFail);
+        THROW_EXCEPTION(ReadFail, "Short read msg body");
     }
 
     if (recv_message_size != _buffer_str.size()) {
-        THROW_EXCEPTION(ReadFail);
+        THROW_EXCEPTION(ReadFail, "Short read other");
     }
 
     if (_metrics) {

--- a/src/comm/Exception.cc
+++ b/src/comm/Exception.cc
@@ -28,10 +28,12 @@
  *
  */
 
+#include "comm/Exception.h"
+
 #include <stdio.h>
 #include <string.h>
-
-#include "comm/Exception.h"
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 void print_exception(const comm::Exception &e, FILE *f)
 {
@@ -41,3 +43,59 @@ void print_exception(const comm::Exception &e, FILE *f)
     else if (!e.msg.empty())
         fprintf(f, "%s\n", e.msg.c_str());
 }
+
+std::ostream& comm::operator<<(std::ostream& os, const comm::Exception& o)
+{
+    static const size_t len = 255;
+    char buf[len+1];
+    buf[len] = 0;
+
+    os << o.file << ':' << o.line << ':'
+       << " comm::Exception={"
+       << "num=" << o.num
+       << ",name='" << o.name << "'"
+       ;
+    if (!o.msg.empty()) {
+        os << ",msg='" << o.msg << "'"
+            ;
+    }
+    int e = o.errno_val;
+    if (e) {
+        buf[0] = 0;
+        os << ",Error={"
+           << "errno=" << e
+           << ",errmsg='" << strerror_r(e, buf, len) << "'"
+           << '}'
+           ;
+    }
+    auto s = o.ssl_err_code;
+    if (s) {
+        const char* err_str = "?";
+        if (false) {
+# define _O(X) } else if (s == X) { err_str = #X;
+       _O(SSL_ERROR_NONE)
+       _O(SSL_ERROR_ZERO_RETURN)
+       _O(SSL_ERROR_WANT_READ)
+       _O(SSL_ERROR_WANT_WRITE)
+       _O(SSL_ERROR_WANT_CONNECT)
+       _O(SSL_ERROR_WANT_ACCEPT)
+       _O(SSL_ERROR_WANT_X509_LOOKUP)
+       _O(SSL_ERROR_WANT_ASYNC)
+       _O(SSL_ERROR_WANT_ASYNC_JOB)
+       _O(SSL_ERROR_WANT_CLIENT_HELLO_CB)
+       _O(SSL_ERROR_SYSCALL)
+       _O(SSL_ERROR_SSL)
+# undef _O
+        }
+        const char* r = ERR_reason_error_string(s);
+        os << ",sslError={"
+           << "err=" << err_str
+           << ",reason='" << (r ? r : "") << "'"
+           << '}'
+           ;
+    }
+    os << '}';
+
+    return os;
+}
+

--- a/src/comm/TLSConnection.cc
+++ b/src/comm/TLSConnection.cc
@@ -10,6 +10,7 @@
 #include <netdb.h>
 #include <string>
 #include <unistd.h>
+#include <glog/logging.h>
 
 #include "comm/Exception.h"
 #include "util/gcc_util.h"
@@ -31,24 +32,51 @@ TLSConnection::TLSConnection(
 {
 }
 
+static long msec_diff(const struct timespec& a,
+                      const struct timespec& b)
+{
+    return
+        (a.tv_sec  - b.tv_sec)  * 1000 +
+        (a.tv_nsec - b.tv_nsec) / 1000000;
+}
+
 size_t TLSConnection::read(uint8_t* buffer, size_t length)
 {
+again:
+    timespec t1;
+    clock_gettime(CLOCK_REALTIME_COARSE, &t1);
+
+    errno = 0;
     auto count = SSL_read(_tls_socket->_ssl, buffer, length);
+    int errno_r = errno;
 
     if (count <= 0) {
         auto error = SSL_get_error(_tls_socket->_ssl, count);
 
-        DISABLE_WARNING(logical-op)
         if (error == SSL_ERROR_ZERO_RETURN) {
-            THROW_EXCEPTION(ConnectionShutDown, "Closing Connection.");
+            THROW_EXCEPTION(ConnectionShutDown, // FIXME -- misleading 'ConnectionShutDown'
+                     errno_r, "SSL_read()", error); // Peer closed conn for writing, so no more reads
         }
-        else if (error == SSL_ERROR_SYSCALL && (!errno || errno == EAGAIN)) {
-            THROW_EXCEPTION(ConnectionShutDown, "Closing Connection.");
+        else if (error == SSL_ERROR_WANT_READ) {
+            if (errno_r == EAGAIN) {
+                timespec t2;
+                clock_gettime(CLOCK_REALTIME_COARSE, &t2);
+                auto dt = msec_diff(t2, t1);
+                VLOG(3) << "SSL_read(): no activity for " << dt << " msec. Going back to reading";
+                goto again;
+            } else {
+                // This error is recoverable. Consider handling it.
+                THROW_EXCEPTION(ReadFail, errno_r, "SSL_read()", error);
+            }
+        }
+        else if (error == SSL_ERROR_SYSCALL ||
+                 error == SSL_ERROR_SSL) {
+            THROW_EXCEPTION(ConnectionShutDown, errno_r, "SSL_read()", error);
+            // FIXME: *we* must close the conn
         }
         else {
-            THROW_EXCEPTION(ReadFail);
+            THROW_EXCEPTION(ReadFail, errno_r, "SSL_read()", error);
         }
-        ENABLE_WARNING(logical-op)
     }
 
     return static_cast<size_t>(count);
@@ -56,10 +84,12 @@ size_t TLSConnection::read(uint8_t* buffer, size_t length)
 
 size_t TLSConnection::write(const uint8_t* buffer, size_t length)
 {
+    errno = 0;
     auto count = SSL_write(_tls_socket->_ssl, buffer, static_cast<int>(length));
-
+    int errno_r = errno;
     if (count <= 0) {
-        THROW_EXCEPTION(WriteFail, "Error sending message.");
+        auto error = SSL_get_error(_tls_socket->_ssl, count);
+        THROW_EXCEPTION(WriteFail, errno_r, "SSL_write()", error);
     }
 
     return static_cast<size_t>(count);

--- a/tools/prometheus_ambassador/SConscript
+++ b/tools/prometheus_ambassador/SConscript
@@ -39,7 +39,7 @@ prom_amb_env.Program('prometheus_ambassador', src)
 
 test_env = prom_amb_env.Clone()
 test_env.Replace(
-    LIBS = prom_amb_env['LIBS'] + ['gtest', 'pthread', 'protobuf'],
+    LIBS = prom_amb_env['LIBS'] + ['gtest', 'pthread', 'protobuf', 'glog'],
     CPPPATH = prom_amb_env['CPPPATH'] + ['../../test', '../../src'],
 )
 

--- a/tools/prometheus_ambassador/SConscript
+++ b/tools/prometheus_ambassador/SConscript
@@ -18,9 +18,9 @@ prom_amb_env.Replace(
                 'aperturedb-client',
                 'prometheus-cpp-core',
                 'prometheus-cpp-pull',
+                'glog',
               ],
     LIBPATH = [ '/usr/local/lib/',
-                '/usr/lib/',
                 os.getenv('AD_COMM_LIB',         default='../../lib'),
                 os.getenv('AD_CLIENT_LIB',       default='../../lib'),
                 os.getenv('JSONCPP_LIB',         default=''),
@@ -40,7 +40,7 @@ prom_amb_env.Program('prometheus_ambassador', src)
 
 test_env = prom_amb_env.Clone()
 test_env.Replace(
-    LIBS = prom_amb_env['LIBS'] + ['glog', 'pthread', 'protobuf', 'gtest'],
+    LIBS = prom_amb_env['LIBS'] + ['pthread', 'protobuf', 'gtest'],
     CPPPATH = prom_amb_env['CPPPATH'] + ['../../test', '../../src'],
 )
 

--- a/tools/prometheus_ambassador/SConscript
+++ b/tools/prometheus_ambassador/SConscript
@@ -20,6 +20,7 @@ prom_amb_env.Replace(
                 'prometheus-cpp-pull',
               ],
     LIBPATH = [ '/usr/local/lib/',
+                '/usr/lib/',
                 os.getenv('AD_COMM_LIB',         default='../../lib'),
                 os.getenv('AD_CLIENT_LIB',       default='../../lib'),
                 os.getenv('JSONCPP_LIB',         default=''),

--- a/tools/prometheus_ambassador/SConscript
+++ b/tools/prometheus_ambassador/SConscript
@@ -40,7 +40,7 @@ prom_amb_env.Program('prometheus_ambassador', src)
 
 test_env = prom_amb_env.Clone()
 test_env.Replace(
-    LIBS = prom_amb_env['LIBS'] + ['gtest', 'pthread', 'protobuf', 'glog'],
+    LIBS = prom_amb_env['LIBS'] + ['glog', 'pthread', 'protobuf', 'gtest'],
     CPPPATH = prom_amb_env['CPPPATH'] + ['../../test', '../../src'],
 )
 


### PR DESCRIPTION
### Purpose
Handle connection time-out.

### Background
We use expiring connection for a better control of resources. The expiration time is a compile-time constant. It is set to be 10 minutes, which was sufficient until now. We encountered a case of deleting 10M nodes that takes 10+ minues. While waiting for the results, the client loses the connection to the server. The connection closedown is initiated by the server.

### Solution
When a IO call returns prematurely, we check that there are no errors at (i) SSL level and (ii) system lib level (except for nominal `EAGAIN` that is used to indicated expiration), and we retry the operation.

### Issues expected to be resolved
Fixes https://github.com/aperture-data/athena/issues/416

### Next step (to be done as a separate PR)
IO error handling is incomplete. E.g. this package can close a connection without notifying the client; the client will only learn that the connection is closed when it tries to write to the socket.
