### PR TITLE
gcc_util for aperturedb-cpp

### DIFF
--- a/include/util/gcc_util.h
+++ b/include/util/gcc_util.h
@@ -19,4 +19,9 @@
 #    endif
 #  endif
 
+// Cleaning after developers of glog 0.5.0:
+#ifndef __SANITIZE_THREAD__
+#define __SANITIZE_THREAD__ 0
+#endif
+
 #endif


### PR DESCRIPTION
### Purpose 
Handle cases when macro __SANITIZE_THREAD__ is used but not checked first if it is defined,