### PR TITLE
Allow custom protobuf ver in aperturedb-cpp

### DIFF
--- a/compiler_warnings.py
+++ b/compiler_warnings.py
@@ -55,6 +55,7 @@ compiler_warnings = [
 "-Wdelete-incomplete",
 "-Wdelete-non-virtual-dtor",
 #"-Wdeprecated-copy",          # N/A
+"-Wdeprecated-declarations",
 #"-Wdeprecated-copy-dtor",     # N/A
 "-Wdisabled-optimization",
 #"-Wdouble-promotion",         # FOR NOW

--- a/src/aperturedb/TokenBasedVDMSClient.cc
+++ b/src/aperturedb/TokenBasedVDMSClient.cc
@@ -29,16 +29,7 @@
  */
 
 #include "aperturedb/VDMSClient.h"
-
-#include "util/gcc_util.h" // DISABLE_WARNING
-DISABLE_WARNING(effc++)
-DISABLE_WARNING(useless-cast)
-DISABLE_WARNING(suggest-override)
-#include "aperturedb/queryMessage.pb.h"
-ENABLE_WARNING(suggest-override)
-ENABLE_WARNING(useless-cast)
-ENABLE_WARNING(effc++)
-
+#include "aperturedb/queryMessageWrapper.h"
 #include "aperturedb/Exception.h"
 #include "comm/ConnClient.h"
 #include "comm/Connection.h"

--- a/src/aperturedb/queryMessageWrapper.h
+++ b/src/aperturedb/queryMessageWrapper.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "util/gcc_util.h" // DISABLE_WARNING
+
+// Cleaning after developers of protobuf 3.9.0:
+#ifndef GOOGLE_PROTOBUF_USE_UNALIGNED
+#define GOOGLE_PROTOBUF_USE_UNALIGNED 0
+#endif
+
+#ifndef GOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE
+#define GOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE 0
+#endif
+
+DISABLE_WARNING(effc++)
+DISABLE_WARNING(useless-cast)
+DISABLE_WARNING(suggest-override)
+DISABLE_WARNING(deprecated-declarations)
+DISABLE_WARNING(shadow)
+DISABLE_WARNING(redundant-decls)
+DISABLE_WARNING(deprecated-declarations)
+#include "aperturedb/queryMessage.pb.h"
+ENABLE_WARNING(deprecated-declarations)
+ENABLE_WARNING(redundant-decls)
+ENABLE_WARNING(shadow)
+ENABLE_WARNING(deprecated-declarations)
+ENABLE_WARNING(suggest-override)
+ENABLE_WARNING(useless-cast)
+ENABLE_WARNING(effc++)

--- a/test/AuthEnabledVDMSServer.cc
+++ b/test/AuthEnabledVDMSServer.cc
@@ -6,15 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "util/gcc_util.h" // DISABLE_WARNING
-DISABLE_WARNING(effc++)
-DISABLE_WARNING(useless-cast)
-DISABLE_WARNING(suggest-override)
-#include "aperturedb/queryMessage.pb.h"
-ENABLE_WARNING(suggest-override)
-ENABLE_WARNING(useless-cast)
-ENABLE_WARNING(effc++)
-
+#include "aperturedb/queryMessageWrapper.h"
 #include "comm/Connection.h"
 #include "comm/ConnServer.h"
 #include "comm/Exception.h"

--- a/test/VDMSServer.cc
+++ b/test/VDMSServer.cc
@@ -3,16 +3,7 @@
  */
 
 #include "VDMSServer.h"
-
-#include "util/gcc_util.h" // DISABLE_WARNING
-DISABLE_WARNING(effc++)
-DISABLE_WARNING(useless-cast)
-DISABLE_WARNING(suggest-override)
-#include "aperturedb/queryMessage.pb.h"
-ENABLE_WARNING(suggest-override)
-ENABLE_WARNING(useless-cast)
-ENABLE_WARNING(effc++)
-
+#include "aperturedb/queryMessageWrapper.h"
 #include "comm/Connection.h"
 #include "comm/ConnServer.h"
 #include "comm/Exception.h"

--- a/tools/prometheus_ambassador/SConscript
+++ b/tools/prometheus_ambassador/SConscript
@@ -14,18 +14,21 @@ prom_amb_env.Replace(
                 os.getenv('PROMETHEUS_CPP_PULL_INCLUDE', default=''),
                 os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include'),
                 os.getenv('GLOG_INCLUDE',          default=''),
+                os.getenv('PROTOBUF_INCLUDE',      default='')
               ],
     LIBPATH = [ '/usr/local/lib/',
                 os.getenv('AD_COMM_LIB',           default='../../lib'),
                 os.getenv('AD_CLIENT_LIB',         default='../../lib'),
                 os.getenv('PROMETHEUS_CPP_LIB',    default=''),
                 os.getenv('GLOG_INCLUDE',          default=''),
+                os.getenv('PROTOBUF_LIB',          default='')
               ],
     LIBS =    [ 'comm',
                 'aperturedb-client',
                 'prometheus-cpp-core',
                 'prometheus-cpp-pull',
                 'glog',
+                'protobuf',
               ],
 )
 

--- a/tools/prometheus_ambassador/test/ClientCollectorTests.cc
+++ b/tools/prometheus_ambassador/test/ClientCollectorTests.cc
@@ -5,22 +5,11 @@
 #include <thread>
 
 #include "gtest/gtest.h"
-
 #include "ClientCollector.h"
 #include "prometheus_ambassador_defines.h"
-
 #include "Barrier.h"
 #include "comm/ConnServer.h"
-
-#include "util/gcc_util.h" // DISABLE_WARNING
-DISABLE_WARNING(effc++)
-DISABLE_WARNING(useless-cast)
-DISABLE_WARNING(suggest-override)
-#include "aperturedb/queryMessage.pb.h"
-ENABLE_WARNING(suggest-override)
-ENABLE_WARNING(useless-cast)
-ENABLE_WARNING(effc++)
-
+#include "aperturedb/queryMessageWrapper.h"
 #include "metrics/JsonWriter.h"
 
 #define SERVER_PORT_INTERCHANGE 43210

--- a/tools/send_query/SConstruct
+++ b/tools/send_query/SConstruct
@@ -11,13 +11,19 @@ send_query_env.Replace(
                 os.getenv('AD_CLIENT_INCLUDE',     default='../../include'),
                 os.getenv('NLOHMANN_JSON_INCLUDE', default='/usr/include'),
                 os.getenv('GLOG_INCLUDE',          default=''),
+                os.getenv('PROTOBUF_INCLUDE',      default='')
     ],
     LIBPATH = ['/usr/local/lib/',
                 os.getenv('AD_COMM_LIB',           default='../../lib'),
                 os.getenv('AD_CLIENT_LIB',         default='../../lib'),
                 os.getenv('GLOG_LIB',              default=''),
+                os.getenv('PROTOBUF_LIB',          default='')
     ],
-    LIBS =    ['libglog', 'comm', 'aperturedb-client', 'glog'],
+    LIBS =    [ 'comm',
+                'aperturedb-client',
+                'glog',
+                'protobuf'
+    ],
 )
 
 files = [ 'send_query.cc' ]


### PR DESCRIPTION
### Purpose
Allow for a custom protobuf version in `aperturedb-cpp`, while your OS can have yet another versions in standard places.

### Status
It works with protobuf versions 3.9.0 (rather old) and 3.20.0 (recent). Each of the two has its ideosyncratic elements that collide with our strict settings for compiler warnings. Now all issues are addressed.

### Detail
1. `PATH` is imported into `SCon*`, so that the proper version of `protoc` compiler is used for creating `*.pb.h` and `*.pb.cc` files.
2. Libs we build now record the location of `protobuf` lib, this avoiding a potentiall crash-on-start when a wrong version of `protobuf` lib is found first. Now the version that was used when bulding the lib is also used at run-time, thus increasing robustness of the apps bult with this lib.

### HOWTO

Have these in a script that you _source_ in a terminal in which you compile and build. Or put these into `~/.bashrc` if you are using same version of protobuf across your project. This example assumes you keep 3rd party stuff in `~/3rdparty`, thus avoiding polluting sys dirs with multiple versions of the package.
```
PROTOBUF_ROOT=${HOME:?}/3rdparty/protobuf-3.20.0
export PROTOBUF_INCLUDE=${PROTOBUF_ROOT:?}/include
export PROTOBUF_LIB=${PROTOBUF_ROOT:?}/lib
export PROTOBUF_BIN=${PROTOBUF_ROOT:?}/bin
export PATH=${PROTOBUF_BIN:?}:$PATH
```
Compilation and building via `scons` should work now. If you change the version number, I recoomend you use `scons -c` before recompiling.