### PR TITLE
ScopeTimer

### DIFF
--- a/include/metrics/README.md
+++ b/include/metrics/README.md
@@ -157,5 +157,3 @@ We currently rely on [*prometheus-cpp*](https://github.com/jupp0r/prometheus-cpp
 * Metric values with templatized value types may provide performance, memory, and/or payload improvements. For example, integer-valued counters.
 ### Remove redundancy
 * Histograms and Summaries currently encode redundant data in the distribution. As an added benefit, this may remove the need to represent infinite floating point values in JSON.
-### Floating-point observation counts
-* This would provide for more nuanced 2-dimensional data in histograms & summaries, for example, "seconds spent per bucket". (It's unclear whether this is supported by prometheus)

--- a/include/metrics/README.md
+++ b/include/metrics/README.md
@@ -157,5 +157,5 @@ We currently rely on [*prometheus-cpp*](https://github.com/jupp0r/prometheus-cpp
 * Metric values with templatized value types may provide performance, memory, and/or payload improvements. For example, integer-valued counters.
 ### Remove redundancy
 * Histograms and Summaries currently encode redundant data in the distribution. As an added benefit, this may remove the need to represent infinite floating point values in JSON.
-### Histogram Nuances
-* We could add the ability to control the count incrementation amount for histogram observation, which would allowing for 2-dimensional floating-point data.  For example, "time spent per bucket".
+### Floating-point observation counts
+* This would provide for more nuanced 2-dimensional data in histograms & summaries, for example, "seconds spent per bucket". (It's unclear whether this is supported by prometheus)

--- a/include/metrics/README.md
+++ b/include/metrics/README.md
@@ -154,6 +154,8 @@ We currently rely on [*prometheus-cpp*](https://github.com/jupp0r/prometheus-cpp
 ### Efficient lookup
 * Lookup of existing metric object is supported by *prometheus-cpp* but inefficient. A more optimized lookup would make metric values more accessible in disjoint places within ApertureDB.
 ### Typed metric values
-* Metric values with templatized value types may provide performance, memory, and/or payload improvements.
+* Metric values with templatized value types may provide performance, memory, and/or payload improvements. For example, integer-valued counters.
 ### Remove redundancy
 * Histograms and Summaries currently encode redundant data in the distribution. As an added benefit, this may remove the need to represent infinite floating point values in JSON.
+### Histogram Nuances
+* We could add the ability to control the count incrementation amount for histogram observation, which would allowing for 2-dimensional floating-point data.  For example, "time spent per bucket".

--- a/include/metrics/Timer.h
+++ b/include/metrics/Timer.h
@@ -31,11 +31,11 @@ private:
     std::unique_ptr< timer_type > _timer;
 
 public:
-    explicit Timer(metric_type* timer = nullptr,
+    explicit Timer(metric_type* metric = nullptr,
         prometheus::Counter* start_counter = nullptr)
     : _timer()
     {
-        reset(timer, start_counter);
+        reset(metric, start_counter);
     }
 
     // not copyable

--- a/include/metrics/Timer.h
+++ b/include/metrics/Timer.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
-#include <time.h>
-#include <math.h>
-#include <chrono>
+#include <memory>
 #include <prometheus/histogram.h>
 #include <prometheus/counter.h>
+#include "util/ScopeTimer.h"
 
 namespace metrics
 {
@@ -23,28 +22,20 @@ template<
 class Timer
 {
 public:
+    using this_type = Timer< METRIC_TYPE, TIME_UNIT >;
     using metric_type = METRIC_TYPE;
-    using duration_type = typename std::chrono::duration< double, typename TIME_UNIT::period >;
+    using timer_type = ScopeTimer< TIME_UNIT, double >;
+    using duration_type = typename timer_type::duration_type;
 
 private:
-    metric_type* _timer;
-    timespec _start;
+    std::unique_ptr< timer_type > _timer;
 
 public:
     explicit Timer(metric_type* timer = nullptr,
         prometheus::Counter* start_counter = nullptr)
-    : _timer(timer)
-    , _start()
+    : _timer()
     {
-        clock_gettime(CLOCK_MONOTONIC, &_start);
-        if (start_counter)
-            start_counter->Increment();
-    }
-
-    ~Timer() {
-        try {
-            reset();
-        } catch (...) {}
+        reset(timer, start_counter);
     }
 
     // not copyable
@@ -53,34 +44,28 @@ public:
 
     // noexcept moveable
     explicit Timer(Timer&& other) noexcept
-    : _timer( other._timer )
-    , _start( std::move(other._start) )
+    : _timer(std::move(other._timer))
     {
-        other._timer = nullptr;
     }
 
     Timer& operator=(Timer&& other) noexcept {
         if (&other != this) {
-            _timer = other._timer;
-            other._timer = nullptr;
-            _start = std::move( other._start );
+            _timer = std::move( other._timer );
         }
         return *this;
     }
 
-    void reset(metric_type* timer = nullptr,
+    void reset(metric_type* metric = nullptr,
         prometheus::Counter* start_counter = nullptr)
     {
-        timespec now;
-        clock_gettime(CLOCK_MONOTONIC, &now);
-        if (_timer) {
-            duration_type dur =
-                std::chrono::nanoseconds(now.tv_nsec - _start.tv_nsec) +
-                std::chrono::seconds(now.tv_sec - _start.tv_sec);
-            _timer->Observe(dur.count());
+        if (metric) {
+            _timer = std::make_unique< timer_type >([metric](double elapsed) {
+                metric->Observe(elapsed);
+            });
         }
-        _timer = timer;
-        _start = std::move( now );
+        else {
+            _timer.reset();
+        }
         if ( start_counter ) start_counter->Increment();
     }
 };

--- a/include/util/ScopeTimer.h
+++ b/include/util/ScopeTimer.h
@@ -13,8 +13,8 @@
 // A scoped timer that calls the provided callback on destruction passing the elapsed time as arg.
 // Usage example:
 // void profile_foo() {
-//     ScopeTimer _timer([](double elapsed){
-//         std::cout << "foo() took " << elapsed << " seconds." << std::endl;
+//     ScopeTimer<> _timer([](double elapsed_sec){
+//         std::cout << "foo() took " << elapsed_sec << " seconds." << std::endl;
 //     });
 //     foo();
 // }
@@ -48,7 +48,7 @@ public:
                 duration_type dur =
                     std::chrono::nanoseconds(now.tv_nsec - _start.tv_nsec) +
                     std::chrono::seconds(now.tv_sec - _start.tv_sec);
-                _cb(dur.count());
+                _cb(std::move(dur).count());
             }
         } catch (...) {}
     }

--- a/include/util/ScopeTimer.h
+++ b/include/util/ScopeTimer.h
@@ -1,0 +1,55 @@
+/**
+ *
+ * @copyright Copyright (c) 2022 ApertureData
+ *
+ */
+
+#pragma once
+
+#include <time.h>
+#include <math.h>
+#include <chrono>
+
+// A scoped timer that calls the provided callback on destruction passing the elapsed time as arg.
+// Usage example:
+// void profile_foo() {
+//     ScopeTimer _timer([](double elapsed){
+//         std::cout << "foo() took " << elapsed << " seconds." << std::endl;
+//     });
+//     foo();
+// }
+template<
+    typename TIME_UNIT = std::chrono::seconds,
+    typename TIME_REP = double
+>
+class ScopeTimer {
+public:
+    using callback_type = std::function< void(TIME_REP) >;
+    using duration_type = typename std::chrono::duration< TIME_REP, typename TIME_UNIT::period >;
+
+private:
+    callback_type _cb;
+    timespec _start;
+
+public:
+    template< typename CALLBACK >
+    explicit ScopeTimer(CALLBACK cb)
+    : _cb(std::move(cb))
+    , _start()
+    {
+        clock_gettime(CLOCK_MONOTONIC, &_start);
+    }
+
+    ~ScopeTimer() {
+        try {
+            timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            if (_cb) {
+                duration_type dur =
+                    std::chrono::nanoseconds(now.tv_nsec - _start.tv_nsec) +
+                    std::chrono::seconds(now.tv_sec - _start.tv_sec);
+                _cb(dur.count());
+            }
+        } catch (...) {}
+    }
+};

--- a/include/util/ScopeTimer.h
+++ b/include/util/ScopeTimer.h
@@ -32,8 +32,7 @@ private:
     timespec _start;
 
 public:
-    template< typename CALLBACK >
-    explicit ScopeTimer(CALLBACK cb)
+    explicit ScopeTimer(callback_type cb)
     : _cb(std::move(cb))
     , _start()
     {


### PR DESCRIPTION
Adds a new utility `ScopeTimer` that measures the duration of its lifecycle using RAII.

e.g.:
```cpp
void critical_operation() {
    ScopeTimer<> _timer([](double elapsed_sec){
        std::cout << "critical_operation() took " << elapsed_sec << " seconds." << std::endl;
    });
    // do stuff
}
```
