### PR TITLE
Add $ORIGIN to rpath

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -111,7 +111,8 @@ client_env.Replace(
         #
         # once the lib is build.
         LIBPATH = ['lib/',
-                    os.getenv('PROTOBUF_LIB', default='')
+                    os.getenv('PROTOBUF_LIB', default=''),
+		    env.Literal('\\$$ORIGIN'))
                   ],
         )
 

--- a/SConstruct
+++ b/SConstruct
@@ -112,7 +112,7 @@ client_env.Replace(
         # once the lib is build.
         LIBPATH = ['lib/',
                     os.getenv('PROTOBUF_LIB', default=''),
-		    env.Literal('\\$$ORIGIN'))
+		    env.Literal('\\$$ORIGIN')
                   ],
         )
 

--- a/github_release.sh
+++ b/github_release.sh
@@ -45,8 +45,10 @@ upload_custom_release_file() {
     docker exec aperturedb bash -c "mkdir -p /x64; cp /usr/local/lib/libprotobuf.so.* /x64"
     docker exec aperturedb bash -c "cp /aperturedb-client/lib/* /x64"
     docker exec aperturedb bash -c "mkdir -p /comm; cp /aperturedb-client/include/comm/* /comm"
+    docker exec aperturedb bash -c "mkdir -p /aperturedb; cp /aperturedb-client/include/aperturedb/* /aperturedb"
     docker cp aperturedb:/x64/ /tmp/aperturedb-cpp/lib/
     docker cp aperturedb:/comm/ /tmp/aperturedb-cpp/include/
+    docker cp aperturedb:/aperturedb/ /tmp/aperturedb-cpp/include/
 
     tar -cvzf libs_64.tgz -C /tmp aperturedb-cpp
     docker stop aperturedb


### PR DESCRIPTION
@luisremis can you please build this and check `$ORIGIN` got effectively added to the library rpath by running this?

```sh
readelf libaperturedb-client.so -d | grep path
```

You should get something like

```sh
0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```