### PR TITLE
Set glog as a comm dependency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -47,7 +47,8 @@ env = Environment(
     # otherwise e.g. '/bin/protoc' would be called and the latter would produce
     # *.pb.* of a version different from the one of $PROTOBUF_INCLUDE dir.
     ENV = {'PATH' : os.environ['PATH']},
-    CXXFLAGS="-std=c++2a " + FFLAGS + OPTFLAGS + WFLAGS
+    CXXFLAGS="-std=c++2a " + FFLAGS + OPTFLAGS + WFLAGS,
+    LINKFLAGS=['-Wl,--no-undefined']
 )
 # env.MergeFlags(GetOption('cflags'))
 
@@ -58,7 +59,7 @@ comm_env.Replace(
                    os.getenv('GLOG_INCLUDE', default=''),
                    os.getenv('PROTOBUF_INCLUDE', default='')
                   ],
-        LIBS    = [],
+        LIBS    = ['glog'],
         LIBPATH = []
              )
 

--- a/github_release.sh
+++ b/github_release.sh
@@ -46,9 +46,11 @@ upload_custom_release_file() {
     docker exec aperturedb bash -c "cp /aperturedb-client/lib/* /x64"
     docker exec aperturedb bash -c "mkdir -p /comm; cp /aperturedb-client/include/comm/* /comm"
     docker exec aperturedb bash -c "mkdir -p /aperturedb; cp /aperturedb-client/include/aperturedb/* /aperturedb"
+    docker exec aperturedb bash -c "mkdir -p /util; cp /aperturedb-client/include/util/Macros.h /util/Macros.h"
     docker cp aperturedb:/x64/ /tmp/aperturedb-cpp/lib/
     docker cp aperturedb:/comm/ /tmp/aperturedb-cpp/include/
     docker cp aperturedb:/aperturedb/ /tmp/aperturedb-cpp/include/
+    docker cp aperturedb:/util/ /tmp/aperturedb-cpp/include/
 
     tar -cvzf libs_64.tgz -C /tmp aperturedb-cpp
     docker stop aperturedb


### PR DESCRIPTION
For some unknown reason the linker is not resolving all symbols so the library crashes at run-time when trying to load them.

This PR is adding the missing dependency and setting ` --no-undefined` to catch/prevent this kind of issues in the future.

Passenger: I'm also adding a missing header to the shipped ones